### PR TITLE
fix: #9 - Parameterize module input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,13 @@ inputs:
   filter-on-changed-files:
     description: "Allowed values: true|false. If set to true, the script will only process changed files."
     required: false
+  modules:
+    description: "Required. Multiline string. List of the modules to install. Format: <moduleName>:<version>"
+    required: false
+    default: |
+      Az.Accounts:3.0.0
+      Az.ResourceGraph:1.0.0
+      Az.Resources:7.1.0
   pattern:
     description: Regex pattern to filter which files will be processed.
     required: false
@@ -38,10 +45,7 @@ runs:
     - name: Install PS Modules
       uses: climpr/install-psmodules@v1
       with:
-        modules: |
-          Az.Accounts:3.0.0
-          Az.ResourceGraph:1.0.0
-          Az.Resources:7.1.0
+        modules: ${{ inputs.modules }}
 
     - name: Deploy Azure Policy
       shell: pwsh

--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: "Allowed values: true|false. If set to true, the script will only process changed files."
     required: false
   modules:
-    description: "Required. Multiline string. List of the modules to install. Format: <moduleName>:<version>"
+    description: "Multiline string. List of the modules to install. Format: <moduleName>:<version>"
     required: false
     default: |
       Az.Accounts:3.0.0

--- a/src/Set-AzurePolicy.ps1
+++ b/src/Set-AzurePolicy.ps1
@@ -1,6 +1,6 @@
-#Requires -Modules @{ ModuleName="Az.Accounts"; ModuleVersion="3.0.0" }
-#Requires -Modules @{ ModuleName="Az.ResourceGraph"; ModuleVersion="1.0.0" }
-#Requires -Modules @{ ModuleName="Az.Resources"; ModuleVersion="7.1.0" }
+#Requires -Modules @{ ModuleName="Az.Accounts"; MinimumVersion="3.0.0" }
+#Requires -Modules @{ ModuleName="Az.ResourceGraph"; MinimumVersion="1.0.0" }
+#Requires -Modules @{ ModuleName="Az.Resources"; MinimumVersion="7.1.0" }
 
 [CmdletBinding()]
 param (


### PR DESCRIPTION
This pull request improves the flexibility and maintainability of the Azure Policy deployment workflow by allowing the required PowerShell modules and their versions to be specified as an input, rather than hardcoding them. It also updates the way required module versions are specified in the PowerShell script.

**Workflow input and module installation improvements:**

* Added a new `modules` input to `action.yaml` to allow specifying a list of PowerShell modules and their versions to install, with a default value provided.
* Updated the module installation step in `action.yaml` to use the new `modules` input instead of hardcoded values.

**PowerShell script requirements:**

* Changed the `#Requires -Modules` statements in `Set-AzurePolicy.ps1` to use `MinimumVersion` instead of `ModuleVersion`, allowing for greater flexibility in module versioning.

Closes #9 