### PR TITLE
Update #requires statement

### DIFF
--- a/src/Set-AzurePolicy.ps1
+++ b/src/Set-AzurePolicy.ps1
@@ -1,4 +1,6 @@
-#Requires -Modules Az.Accounts, Az.ResourceGraph, Az.Resources
+#Requires -Modules @{ ModuleName="Az.Accounts"; ModuleVersion="3.0.0" }
+#Requires -Modules @{ ModuleName="Az.ResourceGraph"; ModuleVersion="1.0.0" }
+#Requires -Modules @{ ModuleName="Az.Resources"; ModuleVersion="7.1.0" }
 
 [CmdletBinding()]
 param (

--- a/src/Set-AzurePolicy.ps1
+++ b/src/Set-AzurePolicy.ps1
@@ -1,6 +1,4 @@
-#Requires -Modules @{ ModuleName="Az.Accounts"; MinimumVersion="3.0.0" }
-#Requires -Modules @{ ModuleName="Az.ResourceGraph"; MinimumVersion="1.0.0" }
-#Requires -Modules @{ ModuleName="Az.Resources"; MinimumVersion="7.1.0" }
+#Requires -Modules Az.Accounts, Az.ResourceGraph, Az.Resources
 
 [CmdletBinding()]
 param (


### PR DESCRIPTION
This pull request makes a minor update to the module requirements in the `src/Set-AzurePolicy.ps1` script. The change switches from using `MinimumVersion` to `ModuleVersion` for specifying lowest allowed module versions.

- Updated module requirement declarations to use `ModuleVersion` instead of `MinimumVersion` for `Az.Accounts`, `Az.ResourceGraph`, and `Az.Resources` in `src/Set-AzurePolicy.ps1`.